### PR TITLE
vm deployment script along with integration and connecting GCP via API

### DIFF
--- a/bin/gcp.py
+++ b/bin/gcp.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import json
+import time
+
+import googleapiclient.discovery
+from oauth2client.service_account import ServiceAccountCredentials
+from six.moves import input
+
+
+CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
+
+with open(os.path.join(CURRENT_FOLDER, '../config/config.json')) as fp:
+    CONFIG = json.load(fp)
+
+
+# [START list_instances]
+def list_instances(compute, project, zone):
+    result = compute.instances().list(project=project, zone=zone).execute()
+    return result['items'] if 'items' in result else None
+# [END list_instances]
+
+# [START create_instance]
+def create_instance(compute, project, zone, name): 
+    # Get the latest Debian Jessie image.
+    image_response = compute.images().getFromFamily(
+        project='debian-cloud', family='debian-9').execute()
+    source_disk_image = image_response['selfLink']
+
+    # Configure the machine
+    machine_type = "zones/%s/machineTypes/n1-standard-1" % zone
+    startup_script = open(
+        os.path.join(
+            os.path.dirname(__file__), 'startup-script.sh'), 'r').read()
+
+    config = {
+        'name': name,
+        'machineType': machine_type,
+
+        # Specify the boot disk and the image to use as a source.
+        'disks': [
+            {
+                'boot': True,
+                'autoDelete': True,
+                'initializeParams': {
+                    'sourceImage': source_disk_image,
+                }
+            }
+        ],
+
+        # Specify a network interface with NAT to access the public
+        # internet.
+        'networkInterfaces': [{
+            'network': 'global/networks/default',
+            'accessConfigs': [
+                {'type': 'ONE_TO_ONE_NAT', 'name': 'External NAT'}
+            ]
+        }],
+
+        # Allow the instance to access cloud storage and logging.
+        'serviceAccounts': [{
+            'email': 'default',
+            'scopes': [
+                'https://www.googleapis.com/auth/devstorage.read_write',
+                'https://www.googleapis.com/auth/logging.write'
+            ]
+        }],
+
+        # Metadata is readable from the instance and allows you to
+        # pass configuration from deployment scripts to instances.
+        'metadata': {
+            'items': [{
+                # Startup script is automatically executed by the
+                # instance upon startup.
+                'key': 'startup-script',
+                'value': startup_script
+             }, {
+            }, #{
+            ]
+        }
+    }
+
+    return compute.instances().insert(
+        project=project,
+        zone=zone,
+        body=config).execute()
+# [END create_instance]
+
+
+# [START wait_for_operation]
+def wait_for_operation(compute, project, zone, operation):
+    print('Waiting for operation to finish...')
+    while True:
+        result = compute.zoneOperations().get(
+            project=project,
+            zone=zone,
+            operation=operation).execute()
+
+        if result['status'] == 'DONE':
+            print("done.")
+            if 'error' in result:
+                raise Exception(result['error'])
+            return result
+
+        time.sleep(1)
+# [END wait_for_operation]
+
+
+# [START run]
+def main(project, zone, instance_name, wait=True): #bucket
+    credentials = ServiceAccountCredentials.from_json_keyfile_dict(CONFIG['service_account'])
+    compute = googleapiclient.discovery.build('compute', 'v1', credentials=credentials)
+
+    print('Creating instance.')
+
+    operation = create_instance(compute, project, zone, instance_name) #bucket
+    wait_for_operation(compute, project, zone, operation['name'])
+
+    instances = list_instances(compute, project, zone)
+
+    print('Instances in project %s and zone %s:' % (project, zone))
+    for instance in instances:
+        print(' - ' + instance['name'])
+
+    print("""
+Instance created.
+It will take a minute or two for the instance to complete work.
+""".format())
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument( '--zone', default='europe-west1-b', help='Compute Engine zone to deploy to.')
+    parser.add_argument( '--name', default='ethinstance', help='New instance name.')
+    args = parser.parse_args()
+    main(CONFIG['service_account']['project_id'], args.zone, args.name)
+# [END run]
+    exit(0)

--- a/bin/main.py
+++ b/bin/main.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
 
     for i in range(1, node_number + 1):
         node_name = 'ethereum{}'.format(i)
-        print('CREATE NODE WITH NAME:', node_name)
+        print('CREATING NODE WITH NAME:', node_name)
         run_file(['python', _get_path('gcp.py'), '--name', node_name])
 
     for interval in intervals:

--- a/bin/main.py
+++ b/bin/main.py
@@ -42,8 +42,8 @@ def run_file(file_path):
         if return_code is not None:
             if return_code:
                 raise Exception(
-                    'File "{}" has not finished successfully'.format(
-                        file_path[1],
+                    'File "{}" has not finished successfully: RETURN CODE {}'.format(
+                        file_path[1], return_code,
                     )
                 )
 
@@ -57,14 +57,22 @@ if __name__ == '__main__':
     print('Starting tool execution...')
     config = load_config(CONFIG_PATH)
     #TODO decide how to give these parameters
-    intervals = range(config['test_param']['minInterval'], config['test_param']['maxInterval']+config['test_param']['intervalStep'], 
+    intervals = range(config['test_param']['minInterval'], config['test_param']['maxInterval']+config['test_param']['intervalStep'],
         config['test_param']['intervalStep'])
-    gasLimit = range(config['test_param']['minGas'], config['test_param']['maxGas']+config['test_param']['gasStep'], 
+    gasLimit = range(config['test_param']['minGas'], config['test_param']['maxGas']+config['test_param']['gasStep'],
         config['test_param']['gasStep'])
-    
+
+    node_number = config['eth_param']['nodeNumber']
+
+    for i in range(1, node_number + 1):
+        node_name = 'ethereum{}'.format(i)
+        print('CREATE NODE WITH NAME:', node_name)
+        run_file(['python', _get_path('gcp.py'), '--name', node_name])
+
     for interval in intervals:
-        for gas in gasLimit:
+         for gas in gasLimit:
             print('Building SUT with block interval ' + str(interval) + 's and ' + str(gas) + ' block gas limit')
+
             run_file(['sh', _get_path('deploy-sut.sh'), str(config['eth_param']['nodeNumber']), str(interval), str(gas),'0'])
             run_file(['python',_get_path('run-caliper.py'), '--interval', str(interval), '--gaslimit', str(gas)])
 

--- a/bin/startup-script.sh
+++ b/bin/startup-script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+apt-get update
+apt-get -y install ethereum
+
+IMAGE_URL=$(curl http://metadata/computeMetadata/v1/instance/attributes/url -H "Metadata-Flavor: Google")
+TEXT=$(curl http://metadata/computeMetadata/v1/instance/attributes/text -H "Metadata-Flavor: Google")
+CS_BUCKET=$(curl http://metadata/computeMetadata/v1/instance/attributes/bucket -H "Metadata-Flavor: Google")
+
+
+

--- a/bin/startup-script.sh
+++ b/bin/startup-script.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+add-apt-repository -y ppa:ethereum/ethereum
 apt-get update
 apt-get -y install ethereum
 

--- a/config/config.json
+++ b/config/config.json
@@ -10,16 +10,14 @@
     	"minInterval": 10,
     	"intervalStep": 5
     },
-    "service_account": {
-        "type": "service_account",
-        "project_id": "totemic-carrier-259013",
-        "private_key_id": "cf2902abd660d2e388adc975949b909a5612d98d",
-        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDEWdyN5ObLq1EJ\nq+KpNpwPvEvStxAzlZoTdU+j+yOgAKK7suagMgM01PvlsuHwC/D7rtytY5+uV1dE\nso0nRLdb/Iq1+sqQOVHZLztuA2MdsfSd3VWqEaFKftyNVrp1oZY0O/b4x4eo0BrI\nWLe2tEit4Selfx8uH5t9U66JjvFlopFMSZphZ8EM5ObbJfg6nM/i7Mg1ZkY4NYWt\nyoeMAg0QBGwqcE/Xx4xBsDCrvkoAivbsBy19ls8J0qmdfEiJLnqMQzy422NwKLQg\n6SoMM2K2EyV1m6q9TMhfrf2epX7NjTG2xUeMVzVOB0OrcycXqkotPtkRIFe2qttU\n4JGtGqRVAgMBAAECggEAVjx/ZSSNBxOhfmVrIdV1umWBSbUUHQvOBVDHHyasUVgm\nINjkeKQui1QlpA8qM0MTXn7Atjhkh+4dSnM/EmmYPILQqzdQIwLBw2j+qYU8UWz4\nmiL9PjoLBExucncOYp6K+TsC7+W2W7q2oJpyaYCJ0TBruMB5wcipAmSv6gOJWxDD\nwLRq0ueUzr7oFPlN/857rWG7ItslzXx4di4OdTqhcstEBzHo9EdVuwh+IzARN0VQ\ndTUzbKr4hymex6560ktbM949v3db6b3kAWwWrKE9Uevi1TwcKdYXcSlo5ZhE0Jsl\nLeR5JqvgXIw+TIkcCyKAKmXITTy/sKnZ0E+6fTrE+wKBgQDoERqjx+kEqTawLx2F\naEvw+L2kEF0q0QTkX6fZuibPLkFa/wFvBFWVQ/jl3oeRhwdmjs/pfwYiWN9PFUxO\nMCgpgqbxJhSKoZkihxjYtROkQuUzJ8BUs59H8kMx0dWLP4cpdLlPb5B2HVV7Ny0d\nHir+zIFkgsTe4131WBfNL3HJhwKBgQDYmc86adHYBkdH0zrUKAS75DeTtKGBCbPu\ntU42vFPmf8iwjNqa9ADkHD4bDp5Ic7FKUcEri8aeiimhM24Mi/6Yut4+OeA/yztU\n5YgmrartJXdpuh6LXLbTFNa/Dg/B9EKg/npRA/CNfulju1Zb1SkVFwSuVe71BZLB\nouNPGFdqQwKBgASVAd+l/NXYuXm1FHIj4wv4/VWV9SD5S41uzhOgd0+z7Bpt2otk\nnIP7+ZggUrDu55iAzV4g4fAfrRkUpJMOpFxddgpg5BrwoeNqo3Tz7lVZ9MiTylph\nyY1UHTuIlxzOvk51PYtx+no6jguGxV9DzzmEtDFV26lC+AH2IVIt06NVAoGAZfMn\nfggW1EZIQL9knj1j1QhbPHO13OWzQnUmJk9IcmLNFISH1I1q6fN9LAEacWG7Hg8T\nDCsTRsYjSBPMBa3THRI/zywwp/ZBq/kJt6LgpBSRezs2a0QtbXcOiQjWU+VjgyGk\ncwOWsxL8SYwA3uKbHqkh8+jQu5Vu+SNxOGZtpr8CgYEAj+nOt20nKL2aFeMSgb9q\nfurUMLJusFG9bI8+swTp8jdJGzXTq8rNoQGV3hJrayCYv/42BfEclLlUwQ2VIDi9\nYbvB2Ii0U3PVlmZ67kaR3qe8vyv3TqSzficIvurygFjPU5jau1SSz2ERiAVEqNsw\n6jItDAiTLg6uNVOVy23E1kU=\n-----END PRIVATE KEY-----\n",
-        "client_email": "totemic-carrier-259013@appspot.gserviceaccount.com",
-        "client_id": "109058290527155817859",
-        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-        "token_uri": "https://oauth2.googleapis.com/token",
-        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/totemic-carrier-259013%40appspot.gserviceaccount.com"
-    }
+  "type": "service_account",
+  "project_id": "totemic-carrier-259013",
+  "private_key_id": "cf2902abd660d2e388adc975949b909a5612d98d",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDEWdyN5ObLq1EJ\nq+KpNpwPvEvStxAzlZoTdU+j+yOgAKK7suagMgM01PvlsuHwC/D7rtytY5+uV1dE\nso0nRLdb/Iq1+sqQOVHZLztuA2MdsfSd3VWqEaFKftyNVrp1oZY0O/b4x4eo0BrI\nWLe2tEit4Selfx8uH5t9U66JjvFlopFMSZphZ8EM5ObbJfg6nM/i7Mg1ZkY4NYWt\nyoeMAg0QBGwqcE/Xx4xBsDCrvkoAivbsBy19ls8J0qmdfEiJLnqMQzy422NwKLQg\n6SoMM2K2EyV1m6q9TMhfrf2epX7NjTG2xUeMVzVOB0OrcycXqkotPtkRIFe2qttU\n4JGtGqRVAgMBAAECggEAVjx/ZSSNBxOhfmVrIdV1umWBSbUUHQvOBVDHHyasUVgm\nINjkeKQui1QlpA8qM0MTXn7Atjhkh+4dSnM/EmmYPILQqzdQIwLBw2j+qYU8UWz4\nmiL9PjoLBExucncOYp6K+TsC7+W2W7q2oJpyaYCJ0TBruMB5wcipAmSv6gOJWxDD\nwLRq0ueUzr7oFPlN/857rWG7ItslzXx4di4OdTqhcstEBzHo9EdVuwh+IzARN0VQ\ndTUzbKr4hymex6560ktbM949v3db6b3kAWwWrKE9Uevi1TwcKdYXcSlo5ZhE0Jsl\nLeR5JqvgXIw+TIkcCyKAKmXITTy/sKnZ0E+6fTrE+wKBgQDoERqjx+kEqTawLx2F\naEvw+L2kEF0q0QTkX6fZuibPLkFa/wFvBFWVQ/jl3oeRhwdmjs/pfwYiWN9PFUxO\nMCgpgqbxJhSKoZkihxjYtROkQuUzJ8BUs59H8kMx0dWLP4cpdLlPb5B2HVV7Ny0d\nHir+zIFkgsTe4131WBfNL3HJhwKBgQDYmc86adHYBkdH0zrUKAS75DeTtKGBCbPu\ntU42vFPmf8iwjNqa9ADkHD4bDp5Ic7FKUcEri8aeiimhM24Mi/6Yut4+OeA/yztU\n5YgmrartJXdpuh6LXLbTFNa/Dg/B9EKg/npRA/CNfulju1Zb1SkVFwSuVe71BZLB\nouNPGFdqQwKBgASVAd+l/NXYuXm1FHIj4wv4/VWV9SD5S41uzhOgd0+z7Bpt2otk\nnIP7+ZggUrDu55iAzV4g4fAfrRkUpJMOpFxddgpg5BrwoeNqo3Tz7lVZ9MiTylph\nyY1UHTuIlxzOvk51PYtx+no6jguGxV9DzzmEtDFV26lC+AH2IVIt06NVAoGAZfMn\nfggW1EZIQL9knj1j1QhbPHO13OWzQnUmJk9IcmLNFISH1I1q6fN9LAEacWG7Hg8T\nDCsTRsYjSBPMBa3THRI/zywwp/ZBq/kJt6LgpBSRezs2a0QtbXcOiQjWU+VjgyGk\ncwOWsxL8SYwA3uKbHqkh8+jQu5Vu+SNxOGZtpr8CgYEAj+nOt20nKL2aFeMSgb9q\nfurUMLJusFG9bI8+swTp8jdJGzXTq8rNoQGV3hJrayCYv/42BfEclLlUwQ2VIDi9\nYbvB2Ii0U3PVlmZ67kaR3qe8vyv3TqSzficIvurygFjPU5jau1SSz2ERiAVEqNsw\n6jItDAiTLg6uNVOVy23E1kU=\n-----END PRIVATE KEY-----\n",
+  "client_email": "totemic-carrier-259013@appspot.gserviceaccount.com",
+  "client_id": "109058290527155817859",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/totemic-carrier-259013%40appspot.gserviceaccount.com"
 }

--- a/config/config.json
+++ b/config/config.json
@@ -9,5 +9,17 @@
     	"maxInterval": 15,
     	"minInterval": 10,
     	"intervalStep": 5
+    },
+    "service_account": {
+        "type": "service_account",
+        "project_id": "totemic-carrier-259013",
+        "private_key_id": "cf2902abd660d2e388adc975949b909a5612d98d",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDEWdyN5ObLq1EJ\nq+KpNpwPvEvStxAzlZoTdU+j+yOgAKK7suagMgM01PvlsuHwC/D7rtytY5+uV1dE\nso0nRLdb/Iq1+sqQOVHZLztuA2MdsfSd3VWqEaFKftyNVrp1oZY0O/b4x4eo0BrI\nWLe2tEit4Selfx8uH5t9U66JjvFlopFMSZphZ8EM5ObbJfg6nM/i7Mg1ZkY4NYWt\nyoeMAg0QBGwqcE/Xx4xBsDCrvkoAivbsBy19ls8J0qmdfEiJLnqMQzy422NwKLQg\n6SoMM2K2EyV1m6q9TMhfrf2epX7NjTG2xUeMVzVOB0OrcycXqkotPtkRIFe2qttU\n4JGtGqRVAgMBAAECggEAVjx/ZSSNBxOhfmVrIdV1umWBSbUUHQvOBVDHHyasUVgm\nINjkeKQui1QlpA8qM0MTXn7Atjhkh+4dSnM/EmmYPILQqzdQIwLBw2j+qYU8UWz4\nmiL9PjoLBExucncOYp6K+TsC7+W2W7q2oJpyaYCJ0TBruMB5wcipAmSv6gOJWxDD\nwLRq0ueUzr7oFPlN/857rWG7ItslzXx4di4OdTqhcstEBzHo9EdVuwh+IzARN0VQ\ndTUzbKr4hymex6560ktbM949v3db6b3kAWwWrKE9Uevi1TwcKdYXcSlo5ZhE0Jsl\nLeR5JqvgXIw+TIkcCyKAKmXITTy/sKnZ0E+6fTrE+wKBgQDoERqjx+kEqTawLx2F\naEvw+L2kEF0q0QTkX6fZuibPLkFa/wFvBFWVQ/jl3oeRhwdmjs/pfwYiWN9PFUxO\nMCgpgqbxJhSKoZkihxjYtROkQuUzJ8BUs59H8kMx0dWLP4cpdLlPb5B2HVV7Ny0d\nHir+zIFkgsTe4131WBfNL3HJhwKBgQDYmc86adHYBkdH0zrUKAS75DeTtKGBCbPu\ntU42vFPmf8iwjNqa9ADkHD4bDp5Ic7FKUcEri8aeiimhM24Mi/6Yut4+OeA/yztU\n5YgmrartJXdpuh6LXLbTFNa/Dg/B9EKg/npRA/CNfulju1Zb1SkVFwSuVe71BZLB\nouNPGFdqQwKBgASVAd+l/NXYuXm1FHIj4wv4/VWV9SD5S41uzhOgd0+z7Bpt2otk\nnIP7+ZggUrDu55iAzV4g4fAfrRkUpJMOpFxddgpg5BrwoeNqo3Tz7lVZ9MiTylph\nyY1UHTuIlxzOvk51PYtx+no6jguGxV9DzzmEtDFV26lC+AH2IVIt06NVAoGAZfMn\nfggW1EZIQL9knj1j1QhbPHO13OWzQnUmJk9IcmLNFISH1I1q6fN9LAEacWG7Hg8T\nDCsTRsYjSBPMBa3THRI/zywwp/ZBq/kJt6LgpBSRezs2a0QtbXcOiQjWU+VjgyGk\ncwOWsxL8SYwA3uKbHqkh8+jQu5Vu+SNxOGZtpr8CgYEAj+nOt20nKL2aFeMSgb9q\nfurUMLJusFG9bI8+swTp8jdJGzXTq8rNoQGV3hJrayCYv/42BfEclLlUwQ2VIDi9\nYbvB2Ii0U3PVlmZ67kaR3qe8vyv3TqSzficIvurygFjPU5jau1SSz2ERiAVEqNsw\n6jItDAiTLg6uNVOVy23E1kU=\n-----END PRIVATE KEY-----\n",
+        "client_email": "totemic-carrier-259013@appspot.gserviceaccount.com",
+        "client_id": "109058290527155817859",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/totemic-carrier-259013%40appspot.gserviceaccount.com"
     }
 }


### PR DESCRIPTION
Added script gcp.py and integrated it into our architecture. Updated config.json.

Description
-The script connects to google cloud based on parameters set inside config.json
-The script is triggered automatically by main.py
-The script creates VMs based on the number of nodes entered by user in config.json and installs ethereum in all of them.

Pre-requisites: (Ubuntu)

sudo apt-get update && sudo apt-get install google-cloud-sdk

gcloud auth login -> opens a window/tab in your deafult browser, enter your google credentials

gcloud config set project my-project -> in our case my-project = "totemic-carrier-259013"



Related Issue
#33 

How Has This Been Tested?
Configure parameters inside config.json and then executed "python main.py" on my local machine.
However, it does not handle deleting nodes, so before executing it for the 2nd time make sure that you delete the nodes first in the GCP project.

Open for discussion:
I think this covers the requirement of #61  as well.
