### PR TITLE
Automated genesis improvements 

### DIFF
--- a/bin/automated-genesis/config.json
+++ b/bin/automated-genesis/config.json
@@ -1,4 +1,7 @@
 {
   "datadir" : "~/private_ethereum_blockchain",
-  "password" : "createpassword"
+  "password" : "createpassword",
+  "nodes" : "3",
+  "gaslimit" : "16000000",
+  "interval" : "5"
 }


### PR DESCRIPTION
Automated genesis improvements #66

## Description
The script receives details via arguments for a number of nodes, gas limit, and block interval
The script creates a new genesis file with the same number of accounts as nodes and the specified gas limit and block interval.
The script also adds the accounts as a sealer node in extra data.

## Related Issue
Automated genesis improvements #66

## Motivation and Context
Modification to the previous script and also enabling to add as a sealer node

## How Has This Been Tested?
go to the script through the terminal and enter python create.py init

Unable to test manually to Public cloud so will be requesting team to integrate it with SUT scipt and test. 


## Types of changes

- [ X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
