### PR TITLE
add min to autoscale group

### DIFF
--- a/bin/deploy-sut.sh
+++ b/bin/deploy-sut.sh
@@ -10,7 +10,7 @@ BLOCK_SIZE=${3}
 NEW_SETUP=${4}
 INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
-INSTANCE_TEMPLATE=ethereum-sut-template
+INSTANCE_TEMPLATE=ethtemplate
 USERNAME=cloudproto
 PASSWORD=cloudproto
 NETWORK_ID=123
@@ -40,6 +40,10 @@ gcloud compute instance-groups managed create ${INSTANCE_GROUP_NAME} \
    --base-instance-name ethereum-sut \
    --size ${NUMBER_NODES} \
    --template ${INSTANCE_TEMPLATE}
+
+gcloud compute instance-groups managed set-autoscaling ${INSTANCE_GROUP_NAME} \
+  --max-num-replicas=${NUMBER_NODES} \
+  --min-num-replicas=${NUMBER_NODES}
 
 echo SLEEPING FOR 30 SECONDS TO MAKE SURE INSTANCES ARE UP!
 sleep 30

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "bin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "@hyperledger/caliper-cli": "^0.2.0",
+    "web3": "^1.2.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
If we don't set a minimus to the instance group autoscaling might kick in and decrease or increase the number of nodes. we want them to be stable.
## Description

https://cloud.google.com/sdk/gcloud/reference/compute/instance-groups/managed/set-autoscaling



## How Has This Been Tested?
I run the the script with run calliper

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- source: https://www.talater.com/open-source-templates/# -->
