### PR TITLE
configuring and using the correct instance name which is set by the user

### DIFF
--- a/bin/deploy-sut.sh
+++ b/bin/deploy-sut.sh
@@ -10,7 +10,7 @@ BLOCK_SIZE=${3}
 NEW_SETUP=${4}
 INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
-INSTANCE_TEMPLATE=ethereum-sut-template
+INSTANCE_TEMPLATE=ethtemplate
 
 #receiving the values of Username, Password and NetworkID from config.json
 USERNAME=$(jq -r '.USERNAME'  ../config/config.json)


### PR DESCRIPTION

## Description

The instance name in deploy-sut.sh was not configured correctly to have the value as "ethtemplate".

## Related Issue

## Motivation and Context

It is important for the master branch to work correctly and not require any changes every time someone wants to test the tool or have a demo.

## How Has This Been Tested?

By executing python main.py and also by executing sh deploy-sut.sh in the bin folder.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
