### PR TITLE
adding gcp setup config

### DIFF
--- a/bin/deploy-sut.sh
+++ b/bin/deploy-sut.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 #Deploy SUT script
-# ./deploy-sut.sh <number of nodes> <block interval> <block size>
+# ./deploy-sut.sh <number of nodes> <block interval> <block size> <1: clean, 0: don't clean previous setup>
 
 set -e
 
 NUMBER_NODES=${1}
 BLOCK_INTERVAL=${2}
 BLOCK_SIZE=${3}
+NEW_SETUP=${4}
 INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=ethereum-sut-template
 
-#receiving the values of GCP Setup, Username, Password and NetworkID from config.json
-NEW_SETUP=$(jq -r '.GCP_SETUP'  ../config/config.json) # 1: clean, 0: don't clean previous setup
+#receiving the values of Username, Password and NetworkID from config.json
 USERNAME=$(jq -r '.USERNAME'  ../config/config.json)
 PASSWORD=$(jq -r '.PASSWORD'  ../config/config.json)
 NETWORK_ID=$(jq -r '.NETWORK_ID'  ../config/config.json)

--- a/bin/deploy-sut.sh
+++ b/bin/deploy-sut.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 #Deploy SUT script
-# ./deploy-sut.sh <number of nodes> <block interval> <block size> <1: clean 0: don't clean previous setup>
+# ./deploy-sut.sh <number of nodes> <block interval> <block size>
 
 set -e
 
 NUMBER_NODES=${1}
 BLOCK_INTERVAL=${2}
 BLOCK_SIZE=${3}
-NEW_SETUP=${4}
 INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=ethereum-sut-template
 
-#receiving the values of Username, Password and NetworkID from config.json
+#receiving the values of GCP Setup, Username, Password and NetworkID from config.json
+NEW_SETUP=$(jq -r '.GCP_SETUP'  ../config/config.json) # 1: clean, 0: don't clean previous setup
 USERNAME=$(jq -r '.USERNAME'  ../config/config.json)
 PASSWORD=$(jq -r '.PASSWORD'  ../config/config.json)
 NETWORK_ID=$(jq -r '.NETWORK_ID'  ../config/config.json)

--- a/bin/main.py
+++ b/bin/main.py
@@ -62,7 +62,7 @@ def check_execution(interval, gaslimit):
     print(tps)
     #TODO check if last value improved enough to continue benchmarking
     return 0
-  
+
 
 def find_min_interval(config):
     intervals = range(1,

--- a/bin/main.py
+++ b/bin/main.py
@@ -2,6 +2,11 @@ from __future__ import print_function
 import os
 import json
 import subprocess
+import sys
+
+
+gcp_setup = sys.argv[1] #1: clean previous setup, 0: don't clean previous setup
+
 
 CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 
@@ -74,7 +79,7 @@ def find_min_interval(config):
         try:
             run_file(
                 ['sh', _get_path('deploy-sut.sh'), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), '0'])
+                 str(config['test_param']['defaultGas']), str(gcp_setup)])
             run_file(['python', _get_path('run-caliper.py'), '--interval', str(interval), '--gaslimit',
                       str(config['test_param']['defaultGas'])])
             # UNCOMMENT ONLY FOR TESTING PURPOSES
@@ -104,7 +109,7 @@ def find_min_gas_limit(config):
             run_file(
                 ['sh', _get_path('deploy-sut.sh'), str(config['eth_param']['nodeNumber']),
                  str(config['test_param']['defaultInterval']),
-                 str(gas), '0'])
+                 str(gas), str(gcp_setup)])
             run_file(['python', _get_path('run-caliper.py'), '--interval', str(config['test_param']['defaultInterval']),
                       '--gaslimit',
                       str(gas)])
@@ -135,7 +140,7 @@ if __name__ == '__main__':
     run_file(
         ['sh', _get_path('deploy-sut.sh'), str(config['eth_param']['nodeNumber']),
          str(config['test_param']['defaultInterval']),
-         str(config['test_param']['defaultGas']), '1'])
+         str(config['test_param']['defaultGas']), str(gcp_setup)])
 
     # Finding the minimum block interval
     min_interval = find_min_interval(config)
@@ -162,7 +167,7 @@ if __name__ == '__main__':
         for gas in gasLimit:
             print('Building SUT with block interval ' + str(interval) + 's and ' + str(gas) + ' block gas limit')
             run_file(['sh', _get_path('deploy-sut.sh'), str(config['eth_param']['nodeNumber']), str(interval), str(gas),
-                      '0'])
+                      str(gcp_setup)])
             run_file(['python', _get_path('run-caliper.py'), '--interval', str(interval), '--gaslimit', str(gas)])
             #if check_execution(interval, gas) is None:
             break

--- a/config/config.json
+++ b/config/config.json
@@ -14,6 +14,7 @@
 	"run_caliper": {
 		"attempt": 3
 	},
+  "GCP_SETUP":"0",
 	"USERNAME": "cloudproto",
 	"PASSWORD":"cloudproto",
 	"NETWORK_ID": 123

--- a/config/config.json
+++ b/config/config.json
@@ -14,7 +14,6 @@
 	"run_caliper": {
 		"attempt": 3
 	},
-  "GCP_SETUP":"0",
 	"USERNAME": "cloudproto",
 	"PASSWORD":"cloudproto",
 	"NETWORK_ID": 123


### PR DESCRIPTION
## Description
Providing an option to the user either to use an existing GCP setup or create a new one. It can be done via setting the value of the parameter GCP_SETUP in the config file.
0: use the existing setup
1: clean the setup

## Related Issue
#91 

## Motivation and Context
It is required because cleaning an existing setup takes a very long time.
It makes sense to configure in the beginning so that execution is faster and more precise.

## How Has This Been Tested?
By executing "python main.py" and also "sh deploy-sut.sh" in the bin folder.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
