### PR TITLE
Change optibench algorithm to avoid repeating find_minimum_gaslimit()

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -183,17 +183,20 @@ def find_optimal_parameters():
         print("Tool execution failed.")
         exit(-1)
 
+    # Finding the minimum block gas limit
+    minimum_gas_limit = find_min_gas_limit(interval)
+    if minimum_gas_limit < 0:
+        # failed to get minimum block gas limit for x interval. Stopping tool execution
+        print("Failed get minimum gas limit.")
+        exit(-1)
+    print("This is minimum gas limit: " + str(minimum_gas_limit))
     optimal = False
 
     while not optimal:
         print("Benchmarking with block interval of " + str(interval) + " seconds.")
         results[interval] = {}
         stop_reached = False
-        # Finding the minimum block gas limit
-        gas = find_min_gas_limit(interval)
-        if gas < 0:
-            # failed to get minimum block gas limit for x interval. Stopping tool execution
-            stop_reached = True
+        gas = minimum_gas_limit
         tries = 0
         gaslimit_queue = queue.Queue()
         while not stop_reached:

--- a/bin/main.py
+++ b/bin/main.py
@@ -105,7 +105,7 @@ def find_min_interval():
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('Benchmarking to find minimum block interval value, current configuration ' + str(
                     interval) + ' seconds and ' +
-                    str(config['test_param']['defaultGas']) + ' gas limit.')
+                      str(config['test_param']['defaultGas']) + ' gas limit.')
                 print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
@@ -232,6 +232,8 @@ def find_current_min_gas_limit(interval, pre_min_gaslimit):
     accuracy = config["test_param"]["gasLimitAccuracy"]
     while not success:
         try:
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print("Calculating minimum gas limit for block interval " + str(interval) + "s")
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
@@ -240,6 +242,9 @@ def find_current_min_gas_limit(interval, pre_min_gaslimit):
                       '--gaslimit',
                       str(pre_min_gaslimit)])
             success = True
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print(
+                    "Minimum block gas limit for block interval " + str(interval) + "s found: " + str(pre_min_gaslimit))
             # UNCOMMENT ONLY FOR TESTING PURPOSES
             # run_file(
             #    ['sh', _get_path('test.sh'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change optibench algorithm to avoid repeating find_minimum_gaslimit(). By put minimum gas limit funciton outside the loop.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#95 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
avoid long looping to fin find minimum gas limit since the minimum gas limit for each interval is not much difference.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running python script main.py

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- source: https://www.talater.com/open-source-templates/# -->
