### PR TITLE
added verification of the existing setup of google cloud project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 
 
-#A benchmarking-based approach to maximize throughput of the private Ethereum
+## A benchmarking-based approach to maximise throughput of the private Ethereum
 
 
 Our goals were to achieve :
-1) Performance Benchmarking. Benchmarking the performance of private Ethereum with Proof-of-Authority consensus  while maximizing throughput depending on block size and block interval. 
+1) Performance Benchmarking. Benchmarking the performance of private Ethereum with Proof-of-Authority consensus  while maximising throughput depending on block size and block interval.
 2) Automation. Scaling dynamically the SUT and to derive and present a few high-level guidelines reducing the complexity of implementing and running blockchain benchmarking performance, which would be valuable to developers and deployment engineers.
 
 
@@ -20,13 +20,13 @@ Our goals were to achieve :
 │   │   ├── deploy-sut.sh
 │   │   ├── startup-script.sh
 │   │   └──create-template.sh
-│   │   
+│   │  
 │   ├── workload
 │   │   ├── caliper-config
 │   │   ├── caliper-reports
 │   │   ├── run-caliper.py
 │   │   └── run-caliper.sh
-│   │   
+│   │  
 │   └── analyzer
 │       ├── old
 │       ├── aggregated-results
@@ -58,8 +58,8 @@ Our goals were to achieve :
 │
 │──  documentation
 └──README.md
-      
-         
+
+
 ```
 
 
@@ -86,19 +86,22 @@ Puppeth
 jq-command
 npm (Node.js)
 Caliper
- 
 
-Note: If you have jq,npm, geth, puppeth and gcloud not installed, you will be provided with the links to follow the easy steps of installing them. This script does not provide their installation, because each user have different OS, and you need to download and install the packages depending on the enviroment you are working from.
+
+Note: If you have jq,npm, geth, puppeth and gcloud not installed, you will be provided with the links to follow the easy steps of installing them. This script does not provide their installation, because each user have different OS, and you need to download and install the packages depending on the environment you are working from.
 
 
 ## Starting the tool
 
 cd cp_ws_1920/bin
 
-python main.py
+python3 main.py (argument-1) (argument-2)
 
+Argument-1 is the verbose levels. We have defined 3 verbose levels: 0,1 and 2, where '0' will print only the result, '1' will print the execution steps and '2' will print everything (recommended for debugging).
 
-## Config (TO-Be-Discussed)
+Argument-2 is related to the Google Cloud project setup. The possible values are 0 and 1, where '0' will use the existing setup after verifying it and '1' will clean the existing setup and create a new Google Cloud project setup.
+
+## Config
 
 config.json has its objects read by the scripts main.py , deploy-sut.sh , create-template.sh and run-caliper.py .
 
@@ -113,7 +116,7 @@ Network_ID to verify the network we are setting the nodes.
 
 
 **The values of "test_param" are all needed to run the main.py.**
- 
+
 "maxGas" sets the maximal gas limit. Our tool aims to set a range for the minimal and maximal gas limit, where depending on the block interval range we give the optimal throughput to the user.
 
 "defaultGas" we set the default gas to make the mining possible, and define the range of min-max block interval
@@ -123,12 +126,12 @@ Network_ID to verify the network we are setting the nodes.
 "maxInterval" sets the maximal block interval. Our tool aims to set a range for the minimal and maximal block interval, where depending on the gas limit range we give the optimal throughput to the user.
 
 "intervalStep" we add it with the default block  interval needed to create new block intervals until we find the minimum block interval.
-	
+
 **"run_caliper" is read by run-caliper.py.**
 "attempt" sets the max attempts to run caliper.
-		
-		
-		
+
+
+
 ## Documentation
 This file serves the user to have a more in depth-learning of this tool and how it was organised and developed by the team.
 
@@ -147,5 +150,3 @@ Takes for input the genesis file and bootnode (just paste address in the bootnod
 
 ### Sealer Node Image
 Takes for input the genesis file and bootnode (just add the address in the bootnode file) and start a mining node that could seal on the default port. It also generated the genesis file accordingly. As Sealers should be in the genesis.json.
-
-

--- a/bin/main.py
+++ b/bin/main.py
@@ -402,18 +402,15 @@ if __name__ == '__main__':
 
 
     # Building SUT for the first time
-    print('Checking if the SUT needs to be built.')
+    print('Checking if the SUT needs to be built for the first time.')
     if gcp_setup == GCP_SETUP_1:
         run_file(
             ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
             str(config['test_param']['maxInterval']),
-            str(config['test_param']['defaultGas']), gcp_setup,
+            str(config['test_param']['defaultGas']), '1',
             '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
             verbose=verbose_level >= VERBOSE_LEVEL_2)
         print('SUT successfully built')
-
-    if gcp_setup == GCP_SETUP_0:
-        print('It is not required to build an SUT at the moment.')
 
 
     print('Starting calculation of optimal block interval and block gas limit for maximum throughput')

--- a/bin/main.py
+++ b/bin/main.py
@@ -395,15 +395,22 @@ if __name__ == '__main__':
     # Backing up old results
     run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
 
+
     # Building SUT for the first time
-    print('Building the SUT')
-    run_file(
-        ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
-         str(config['test_param']['maxInterval']),
-         str(config['test_param']['defaultGas']), '1',
-         '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-        verbose=verbose_level >= VERBOSE_LEVEL_2)
-    print('SUT successfully built')
+    print('Checking if the SUT needs to be built.')
+    if gcp_setup == GCP_SETUP_1:
+        run_file(
+            ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
+            str(config['test_param']['maxInterval']),
+            str(config['test_param']['defaultGas']), '1',
+            '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+            verbose=verbose_level >= VERBOSE_LEVEL_2)
+        print('SUT successfully built')
+
+    if gcp_setup == GCP_SETUP_0:
+        print('It is not required to build an SUT at the moment.')
+
+
     print('Starting calculation of optimal block interval and block gas limit for maximum throughput')
     result = find_optimal_parameters()
     print("Best result found: " + str(result))

--- a/bin/main.py
+++ b/bin/main.py
@@ -110,7 +110,7 @@ def find_min_interval():
                 print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), str(gcp_setup),
+                 str(config['test_param']['defaultGas']), '0',
                  '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
@@ -156,7 +156,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level == VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -191,7 +191,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -267,7 +267,7 @@ def find_optimal_parameters():
                 run_file(
                     ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                      str(interval),
-                     str(gas), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                     str(gas), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                     verbose=verbose_level >= VERBOSE_LEVEL_2)
                 if verbose_level >= VERBOSE_LEVEL_1:
                     print('SUT successfully built')
@@ -400,7 +400,7 @@ if __name__ == '__main__':
     run_file(
         ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
          str(config['test_param']['maxInterval']),
-         str(config['test_param']['defaultGas']), str(gcp_setup),
+         str(config['test_param']['defaultGas']), '1',
          '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
         verbose=verbose_level >= VERBOSE_LEVEL_2)
     print('SUT successfully built')

--- a/bin/main.py
+++ b/bin/main.py
@@ -115,7 +115,7 @@ def find_min_interval():
                 print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), '0',
+                 str(config['test_param']['defaultGas']), gcp_setup,
                  '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
@@ -161,7 +161,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level == VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -196,7 +196,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -272,7 +272,7 @@ def find_optimal_parameters():
                 run_file(
                     ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                      str(interval),
-                     str(gas), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                     str(gas), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                     verbose=verbose_level >= VERBOSE_LEVEL_2)
                 if verbose_level >= VERBOSE_LEVEL_1:
                     print('SUT successfully built')
@@ -407,7 +407,7 @@ if __name__ == '__main__':
         run_file(
             ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
             str(config['test_param']['maxInterval']),
-            str(config['test_param']['defaultGas']), '1',
+            str(config['test_param']['defaultGas']), gcp_setup,
             '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
             verbose=verbose_level >= VERBOSE_LEVEL_2)
         print('SUT successfully built')

--- a/bin/main.py
+++ b/bin/main.py
@@ -13,11 +13,12 @@ CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 # 2: Print everything
 
 verbose_level = int(sys.argv[1])
+user_input = int(sys.argv[2])
 VERBOSE_LEVEL_0 = 0
 VERBOSE_LEVEL_1 = 1
 VERBOSE_LEVEL_2 = 2
 
-ANALYZER_PATH = "analyzer/"
+ANALYZER_PATH ="analyzer/"
 SUT_PATH = "sut/"
 WORKLOAD_PATH = "workload/"
 DEPLOY_SUT_PATH = SUT_PATH + "deploy-sut.sh"
@@ -35,6 +36,7 @@ CONFIG_PATH = os.path.join(_get_path('../config'), 'config.json')
 
 
 def load_config(path):
+    print('Reading user configuration...')
     with open(path) as fp:
         config = json.load(fp)
 
@@ -85,14 +87,12 @@ def run_file(file_path, verbose=True):
 
 def get_last_tps(interval, gaslimit):
     run_file(['python', _get_path(GET_LAST_RESULT_PATH), '--interval', str(interval), '--gaslimit',
-              str(gaslimit)],
-             verbose=verbose_level >= VERBOSE_LEVEL_2)
+              str(gaslimit), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
     tps = 0
     with open('last-tps', "r") as file:
         tps = float(file.read())
-    if verbose_level >= VERBOSE_LEVEL_1:
-        print("Last execution tps for block interval " + str(interval) + " seconds and " + str(
-            gaslimit) + " gas limit: " + str(tps))
+    print("Last execution tps for block interval " + str(interval) + " seconds and " + str(
+        gaslimit) + " gas limit: " + str(tps))
     return tps
 
 
@@ -101,36 +101,25 @@ def find_min_interval():
                       config['test_param']['maxInterval'] + config['test_param']['intervalStep'],
                       config['test_param']['intervalStep'])
     for interval in intervals:
+        print('Benchmarking to find minimum block interval value, current configuration ' + str(
+            interval) + ' seconds and ' +
+              str(config['test_param']['defaultGas']) + ' gas limit.')
         try:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Benchmarking to find minimum block interval value, current configuration ' + str(
-                    interval) + ' seconds and ' +
-                    str(config['test_param']['defaultGas']) + ' gas limit.')
-                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), '0',
-                 '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-                verbose=verbose_level >= VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('SUT successfully built')
-                print('Executing the workload')
+                 str(config['test_param']['defaultGas']), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval), '--gaslimit',
-                      str(config['test_param']['defaultGas'])],
-                     verbose=verbose_level == VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Workload executed')
+                      str(config['test_param']['defaultGas']), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level==VERBOSE_LEVEL_2)
+
             # UNCOMMENT ONLY FOR TESTING PURPOSES
             # run_file(
             #    ['sh', _get_path('test.sh'), str(interval),
             #     str(config['test_param']['defaultGas'])])
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Minimum block interval found! ' + str(interval) + ' seconds.')
+            print('Minimum block interval found! ' + str(interval) + ' seconds.')
             return interval
         except Exception as e:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                    str(interval), str(config['test_param']['defaultGas']), e))
+            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                str(interval), str(config['test_param']['defaultGas']), e))
 
     print(
         'Minimum block interval not found. Check again your setup or '
@@ -141,89 +130,65 @@ def find_min_interval():
 def find_min_gas_limit(interval):
     upper_bound = config['test_param']['minGas']
     lower_bound = upper_bound
-    if verbose_level >= VERBOSE_LEVEL_1:
-        print("Benchmarking to find minimum block gas limit value for block interval dimension of " + str(
-            interval) + " seconds.")
+
+    print("Benchmarking to find minimum block gas limit value for block interval dimension of " + str(
+        interval) + " seconds.")
     # Benchmarking to get initial upper bound
     while True:
         try:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print(
-                    "Benchmarking with block interval of " + str(interval) + " seconds and " + str(
-                        upper_bound) + " gas limit.")
-                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-                verbose=verbose_level == VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('SUT successfully built')
-                print('Executing the workload')
+                 str(upper_bound), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''])
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
                       '--gaslimit',
-                      str(upper_bound)], verbose=verbose_level == VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Workload executed')
+                      str(upper_bound)], verbose=verbose_level==VERBOSE_LEVEL_2)
             # yes
             break
         except Exception as e:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                    str(interval), str(upper_bound), e))
+            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                str(interval), str(upper_bound), e))
         # no
         lower_bound = upper_bound
         upper_bound = int(upper_bound * 2)
     working_upper_bound = upper_bound
     upper_bound = int((upper_bound + lower_bound) / 2)
-    if verbose_level >= VERBOSE_LEVEL_1:
-        print("A working gas limit upper bound has been found: " + str(upper_bound))
+    print("A working gas limit upper bound has been found: " + str(upper_bound))
     accuracy = config["test_param"]["gasLimitAccuracy"]
 
     # Benchmarking upper bound
     while True:
+        print("Benchmarking with " + str(upper_bound) + " upper bound and " + str(
+            lower_bound) + " lower bound to find the minimum gas limit")
         try:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print("Benchmarking with " + str(upper_bound) + " upper bound and " + str(
-                    lower_bound) + " lower bound to find the minimum gas limit")
-                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-                verbose=verbose_level >= VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('SUT successfully built')
-                print('Executing the workload')
+                 str(upper_bound), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
-                      '--gaslimit', str(upper_bound)], verbose=verbose_level >= VERBOSE_LEVEL_2)
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Workload executed')
+                      '--gaslimit',
+                      str(upper_bound), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
+
             # UNCOMMENT ONLY FOR TESTING PURPOSES
             # run_file(
             #    ['sh', _get_path('test.sh'),
             #     str(config['test_param']['defaultInterval']), str(gas)])
 
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Calculating if the gas limit is under accuracy bounds')
             # Is inside the accuracy expected?
             if accuracy >= (abs(upper_bound - lower_bound)):
                 break
             else:
-                # no
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('Not inside accuracy bounds, continuing find minimum gas limit execution')
+                # yes
                 working_upper_bound = upper_bound
                 upper_bound = int((upper_bound + lower_bound) / 2)
         except Exception as e:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                    str(interval), str(upper_bound), e))
+            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                str(interval), str(upper_bound), e))
             # no
             lower_bound = upper_bound
             upper_bound = int((lower_bound + working_upper_bound) / 2)
-    if verbose_level >= VERBOSE_LEVEL_1:
-        print("Minimum gas limit bound found: " + str(upper_bound))
+
+    print("Minimum gas limit bound found: " + str(upper_bound))
     return upper_bound
 
 
@@ -244,8 +209,7 @@ def find_optimal_parameters():
     optimal = False
 
     while not optimal:
-        if verbose_level >= VERBOSE_LEVEL_1:
-            print("Performing benchmarks with block interval of " + str(interval) + " seconds.")
+        print("Benchmarking with block interval of " + str(interval) + " seconds.")
         results[interval] = {}
         stop_reached = False
         # Finding the minimum block gas limit
@@ -256,31 +220,20 @@ def find_optimal_parameters():
         tries = 0
         gaslimit_queue = queue.Queue()
         while not stop_reached:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print(
-                    "Benchmarking with block interval of " + str(interval) + " seconds and " + str(gas) + " gas limit.")
+            print("Benchmarking with block interval of " + str(interval) + " seconds and " + str(gas) + " gas limit.")
             # benchmarking with block interval x and block gas limit y
             try:
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('Building SUT')
                 run_file(
                     ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                      str(interval),
-                     str(gas), '0', '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-                    verbose=verbose_level >= VERBOSE_LEVEL_2)
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('SUT successfully built')
-                    print('Executing the workload')
+                     str(gas), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
                 run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
-                          '--gaslimit', str(gas)], verbose=verbose_level >= VERBOSE_LEVEL_2)
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('Workload executed')
+                          '--gaslimit',
+                          str(gas)])
                 # UNCOMMENT ONLY FOR TESTING PURPOSES
                 # run_file(
                 #    ['sh', _get_path('test.sh'),
                 #     str(config['test_param']['defaultInterval']), str(gas)])
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('Obtaining peak and checking to continue or not')
                 last_tps = get_last_tps(interval, gas)
                 results[interval][gas] = last_tps
                 # Is optimal gas limit for x interval found?
@@ -291,8 +244,7 @@ def find_optimal_parameters():
                         x = gaslimit_queue.get(False)
                         tmp_queue.put(x)
                         tmp = 1 - (x / last_tps)
-                        if verbose_level >= VERBOSE_LEVEL_2:
-                            print("Sensitivity: " + str(tmp))
+                        print("Sensitivity: " + str(tmp))
                         if tmp > sensitivity:
                             improvement = True
                     gaslimit_queue = tmp_queue
@@ -301,33 +253,24 @@ def find_optimal_parameters():
                     if not improvement:
                         # yes
                         stop_reached = True
-                        if verbose_level >= VERBOSE_LEVEL_1:
-                            print("Improvement less than the sensitivity given, last feasible gas limit found")
+                        print("Improvement less than the sensitivity given, last feasible gas limit found")
                     else:
                         # no
-                        if verbose_level >= VERBOSE_LEVEL_1:
-                            print("No improvement found, continue with interval " + str(interval) + " seconds")
                         gas += gas_step
                 else:
                     # no, we need more trials
-                    if verbose_level >= VERBOSE_LEVEL_1:
-                        print("Tool needs more data, continue with interval " + str(interval) + " seconds")
                     gaslimit_queue.put(last_tps)
                     gas += gas_step
             except Exception as e:
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                        str(interval), str(gas), e))
+                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                    str(interval), str(gas), e))
                 results[interval][gas] = -1
                 gaslimit_queue.put(-1)
                 # Crash found, yes
                 if tries > trials:
                     stop_reached = True
-                    if verbose_level >= VERBOSE_LEVEL_1:
-                        print("Crash in benchmarking execution, last feasible gas limit found")
+                    print("Crash in benchmarking execution, last feasible gas limit found")
                 else:
-                    if verbose_level >= VERBOSE_LEVEL_1:
-                        print("Tool needs more data, continue with interval " + str(interval) + " seconds")
                     gas += gas_step
 
             tries += 1
@@ -341,21 +284,17 @@ def find_optimal_parameters():
                 max_value = value
                 max_key = key
         last_peak = max_value
-        if verbose_level >= VERBOSE_LEVEL_1:
-            print(
-                "Peak in block interval " + str(interval) + " seconds found. Found in "
-                + str(max_key) + " gas limit with " + str(last_peak) + " TPS.")
+        print(
+            "Peak in block interval " + str(interval) + " seconds found. Found in "
+            + str(max_key) + " gas limit with " + str(last_peak) + " TPS.")
         # saving the last peak in the array of peaks
         peaks.append({str(interval) + ":" + str(max_key): max_value})
         # can we improve more the tps?
         if len(peaks) > trials:
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print("Checking to continue for more intervals or not")
             pos = trials + 1
             improvement = False
             while pos > 1:
-                if verbose_level >= VERBOSE_LEVEL_2:
-                    print("Peak calc: " + str(peaks[-pos].values()))
+                print("Peak calc: " + str(peaks[-pos].values()))
                 tmp = 1 - (next(iter(peaks[-pos].values())) / last_peak)
                 if tmp > sensitivity:
                     improvement = True
@@ -363,17 +302,12 @@ def find_optimal_parameters():
             if not improvement:
                 # no
                 optimal = True
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print("Improvement less than the sensitivity given, peak found")
+                print("Improvement less than the sensitivity given, last feasible combination found")
             else:
-                # no
-                if verbose_level >= VERBOSE_LEVEL_1:
-                    print("No improvement found, continue execution")
+                # yes
                 interval += interval_step
         else:
-            # no
-            if verbose_level >= VERBOSE_LEVEL_1:
-                print("Tool needs more data, continue execution")
+            # yes
             interval += interval_step
 
     # no more improvement expected, getting the maximum tps with its parameters
@@ -389,26 +323,22 @@ def find_optimal_parameters():
 
 
 if __name__ == '__main__':
-    print('Starting tool execution')
+    print('Starting tool execution...')
     start_time = time.time()
     # Backing up old results
-    run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
+    run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level==VERBOSE_LEVEL_2)
 
     # Building SUT for the first time
-    print('Building the SUT')
     run_file(
         ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
          str(config['test_param']['maxInterval']),
-         str(config['test_param']['defaultGas']), '1',
-         '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-        verbose=verbose_level >= VERBOSE_LEVEL_2)
-    print('SUT successfully built')
-    print('Starting calculation of optimal block interval and block gas limit for maximum throughput')
+         str(config['test_param']['defaultGas']),
+         str(user_input)], verbose=verbose_level>=VERBOSE_LEVEL_1)
+
     result = find_optimal_parameters()
     print("Best result found: " + str(result))
-    if verbose_level >= VERBOSE_LEVEL_1:
-        print('Aggregating all the workload reports')
-    run_file(['python', _get_path(AGGREGATE_RESULTS_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
+    print('Aggregating all the workload reports')
+    run_file(['python', _get_path(AGGREGATE_RESULTS_PATH)], verbose=verbose_level==VERBOSE_LEVEL_0)
     exec_time = (time.time() - start_time)
     print("Execution time: " + str(exec_time))
     exit(0)

--- a/bin/main.py
+++ b/bin/main.py
@@ -13,10 +13,15 @@ CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 # 2: Print everything
 
 verbose_level = int(sys.argv[1])
-gcp_setup = int(sys.argv[2])
+
 VERBOSE_LEVEL_0 = 0
 VERBOSE_LEVEL_1 = 1
 VERBOSE_LEVEL_2 = 2
+
+gcp_setup = int(sys.argv[2])
+
+GCP_SETUP_0 = 0
+GCP_SETUP_1 = 1
 
 ANALYZER_PATH = "analyzer/"
 SUT_PATH = "sut/"

--- a/bin/main.py
+++ b/bin/main.py
@@ -55,6 +55,14 @@ def load_config(path):
 config = load_config(CONFIG_PATH)
 
 
+#def run_file(file_path, verbose=True):
+#    process = subprocess.Popen(
+#        file_path,
+#        stdout=subprocess.PIPE,
+#        stderr=subprocess.PIPE,
+#        universal_newlines=True
+#    )
+
 def run_file(file_path, verbose=True):
     process = subprocess.Popen(
         file_path,
@@ -62,6 +70,31 @@ def run_file(file_path, verbose=True):
         stderr=subprocess.PIPE,
         universal_newlines=True
     )
+
+    while True:
+        output = process.stdout.readline()
+        err_output = process.stderr.readline()
+        if verbose:
+            print(output.strip())
+            print(err_output.strip())
+
+        return_code = process.poll()
+        if return_code is not None:
+            for output in process.stdout.readlines():
+                if verbose:
+                    print(output.strip())
+            for output in process.stderr.readlines():
+                if verbose:
+                    print(output.strip())
+
+            if return_code:
+                raise Exception(
+                    'File "{}" has not finished successfully'.format(
+                        file_path[1],
+                    )
+                )
+
+            break
 
     while True:
         output = process.stdout.readline()

--- a/bin/main.py
+++ b/bin/main.py
@@ -13,12 +13,12 @@ CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 # 2: Print everything
 
 verbose_level = int(sys.argv[1])
-user_input = int(sys.argv[2])
+gcp_setup = int(sys.argv[2])
 VERBOSE_LEVEL_0 = 0
 VERBOSE_LEVEL_1 = 1
 VERBOSE_LEVEL_2 = 2
 
-ANALYZER_PATH ="analyzer/"
+ANALYZER_PATH = "analyzer/"
 SUT_PATH = "sut/"
 WORKLOAD_PATH = "workload/"
 DEPLOY_SUT_PATH = SUT_PATH + "deploy-sut.sh"
@@ -36,7 +36,6 @@ CONFIG_PATH = os.path.join(_get_path('../config'), 'config.json')
 
 
 def load_config(path):
-    print('Reading user configuration...')
     with open(path) as fp:
         config = json.load(fp)
 
@@ -87,12 +86,14 @@ def run_file(file_path, verbose=True):
 
 def get_last_tps(interval, gaslimit):
     run_file(['python', _get_path(GET_LAST_RESULT_PATH), '--interval', str(interval), '--gaslimit',
-              str(gaslimit), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
+              str(gaslimit)],
+             verbose=verbose_level >= VERBOSE_LEVEL_2)
     tps = 0
     with open('last-tps', "r") as file:
         tps = float(file.read())
-    print("Last execution tps for block interval " + str(interval) + " seconds and " + str(
-        gaslimit) + " gas limit: " + str(tps))
+    if verbose_level >= VERBOSE_LEVEL_1:
+        print("Last execution tps for block interval " + str(interval) + " seconds and " + str(
+            gaslimit) + " gas limit: " + str(tps))
     return tps
 
 
@@ -101,25 +102,36 @@ def find_min_interval():
                       config['test_param']['maxInterval'] + config['test_param']['intervalStep'],
                       config['test_param']['intervalStep'])
     for interval in intervals:
-        print('Benchmarking to find minimum block interval value, current configuration ' + str(
-            interval) + ' seconds and ' +
-              str(config['test_param']['defaultGas']) + ' gas limit.')
         try:
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Benchmarking to find minimum block interval value, current configuration ' + str(
+                    interval) + ' seconds and ' +
+                    str(config['test_param']['defaultGas']) + ' gas limit.')
+                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
+                 str(config['test_param']['defaultGas']), str(gcp_setup),
+                 '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                verbose=verbose_level >= VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('SUT successfully built')
+                print('Executing the workload')
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval), '--gaslimit',
-                      str(config['test_param']['defaultGas']), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level==VERBOSE_LEVEL_2)
-
+                      str(config['test_param']['defaultGas'])],
+                     verbose=verbose_level == VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Workload executed')
             # UNCOMMENT ONLY FOR TESTING PURPOSES
             # run_file(
             #    ['sh', _get_path('test.sh'), str(interval),
             #     str(config['test_param']['defaultGas'])])
-            print('Minimum block interval found! ' + str(interval) + ' seconds.')
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Minimum block interval found! ' + str(interval) + ' seconds.')
             return interval
         except Exception as e:
-            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                str(interval), str(config['test_param']['defaultGas']), e))
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                    str(interval), str(config['test_param']['defaultGas']), e))
 
     print(
         'Minimum block interval not found. Check again your setup or '
@@ -130,65 +142,89 @@ def find_min_interval():
 def find_min_gas_limit(interval):
     upper_bound = config['test_param']['minGas']
     lower_bound = upper_bound
-
-    print("Benchmarking to find minimum block gas limit value for block interval dimension of " + str(
-        interval) + " seconds.")
+    if verbose_level >= VERBOSE_LEVEL_1:
+        print("Benchmarking to find minimum block gas limit value for block interval dimension of " + str(
+            interval) + " seconds.")
     # Benchmarking to get initial upper bound
     while True:
         try:
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print(
+                    "Benchmarking with block interval of " + str(interval) + " seconds and " + str(
+                        upper_bound) + " gas limit.")
+                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''])
+                 str(upper_bound), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                verbose=verbose_level == VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('SUT successfully built')
+                print('Executing the workload')
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
                       '--gaslimit',
-                      str(upper_bound)], verbose=verbose_level==VERBOSE_LEVEL_2)
+                      str(upper_bound)], verbose=verbose_level == VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Workload executed')
             # yes
             break
         except Exception as e:
-            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                str(interval), str(upper_bound), e))
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                    str(interval), str(upper_bound), e))
         # no
         lower_bound = upper_bound
         upper_bound = int(upper_bound * 2)
     working_upper_bound = upper_bound
     upper_bound = int((upper_bound + lower_bound) / 2)
-    print("A working gas limit upper bound has been found: " + str(upper_bound))
+    if verbose_level >= VERBOSE_LEVEL_1:
+        print("A working gas limit upper bound has been found: " + str(upper_bound))
     accuracy = config["test_param"]["gasLimitAccuracy"]
 
     # Benchmarking upper bound
     while True:
-        print("Benchmarking with " + str(upper_bound) + " upper bound and " + str(
-            lower_bound) + " lower bound to find the minimum gas limit")
         try:
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print("Benchmarking with " + str(upper_bound) + " upper bound and " + str(
+                    lower_bound) + " lower bound to find the minimum gas limit")
+                print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
+                 str(upper_bound), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                verbose=verbose_level >= VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('SUT successfully built')
+                print('Executing the workload')
             run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
-                      '--gaslimit',
-                      str(upper_bound), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
-
+                      '--gaslimit', str(upper_bound)], verbose=verbose_level >= VERBOSE_LEVEL_2)
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Workload executed')
             # UNCOMMENT ONLY FOR TESTING PURPOSES
             # run_file(
             #    ['sh', _get_path('test.sh'),
             #     str(config['test_param']['defaultInterval']), str(gas)])
 
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Calculating if the gas limit is under accuracy bounds')
             # Is inside the accuracy expected?
             if accuracy >= (abs(upper_bound - lower_bound)):
                 break
             else:
-                # yes
+                # no
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('Not inside accuracy bounds, continuing find minimum gas limit execution')
                 working_upper_bound = upper_bound
                 upper_bound = int((upper_bound + lower_bound) / 2)
         except Exception as e:
-            print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                str(interval), str(upper_bound), e))
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                    str(interval), str(upper_bound), e))
             # no
             lower_bound = upper_bound
             upper_bound = int((lower_bound + working_upper_bound) / 2)
-
-    print("Minimum gas limit bound found: " + str(upper_bound))
+    if verbose_level >= VERBOSE_LEVEL_1:
+        print("Minimum gas limit bound found: " + str(upper_bound))
     return upper_bound
 
 
@@ -209,7 +245,8 @@ def find_optimal_parameters():
     optimal = False
 
     while not optimal:
-        print("Benchmarking with block interval of " + str(interval) + " seconds.")
+        if verbose_level >= VERBOSE_LEVEL_1:
+            print("Performing benchmarks with block interval of " + str(interval) + " seconds.")
         results[interval] = {}
         stop_reached = False
         # Finding the minimum block gas limit
@@ -220,20 +257,31 @@ def find_optimal_parameters():
         tries = 0
         gaslimit_queue = queue.Queue()
         while not stop_reached:
-            print("Benchmarking with block interval of " + str(interval) + " seconds and " + str(gas) + " gas limit.")
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print(
+                    "Benchmarking with block interval of " + str(interval) + " seconds and " + str(gas) + " gas limit.")
             # benchmarking with block interval x and block gas limit y
             try:
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('Building SUT')
                 run_file(
                     ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                      str(interval),
-                     str(gas), str(user_input), '--no-user-output-enabled' if verbose_level==VERBOSE_LEVEL_0 else ''], verbose=verbose_level>=VERBOSE_LEVEL_1)
+                     str(gas), str(gcp_setup), '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                    verbose=verbose_level >= VERBOSE_LEVEL_2)
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('SUT successfully built')
+                    print('Executing the workload')
                 run_file(['python', _get_path(RUN_WORKLOAD_PATH), '--interval', str(interval),
-                          '--gaslimit',
-                          str(gas)])
+                          '--gaslimit', str(gas)], verbose=verbose_level >= VERBOSE_LEVEL_2)
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('Workload executed')
                 # UNCOMMENT ONLY FOR TESTING PURPOSES
                 # run_file(
                 #    ['sh', _get_path('test.sh'),
                 #     str(config['test_param']['defaultInterval']), str(gas)])
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('Obtaining peak and checking to continue or not')
                 last_tps = get_last_tps(interval, gas)
                 results[interval][gas] = last_tps
                 # Is optimal gas limit for x interval found?
@@ -244,7 +292,8 @@ def find_optimal_parameters():
                         x = gaslimit_queue.get(False)
                         tmp_queue.put(x)
                         tmp = 1 - (x / last_tps)
-                        print("Sensitivity: " + str(tmp))
+                        if verbose_level >= VERBOSE_LEVEL_2:
+                            print("Sensitivity: " + str(tmp))
                         if tmp > sensitivity:
                             improvement = True
                     gaslimit_queue = tmp_queue
@@ -253,24 +302,33 @@ def find_optimal_parameters():
                     if not improvement:
                         # yes
                         stop_reached = True
-                        print("Improvement less than the sensitivity given, last feasible gas limit found")
+                        if verbose_level >= VERBOSE_LEVEL_1:
+                            print("Improvement less than the sensitivity given, last feasible gas limit found")
                     else:
                         # no
+                        if verbose_level >= VERBOSE_LEVEL_1:
+                            print("No improvement found, continue with interval " + str(interval) + " seconds")
                         gas += gas_step
                 else:
                     # no, we need more trials
+                    if verbose_level >= VERBOSE_LEVEL_1:
+                        print("Tool needs more data, continue with interval " + str(interval) + " seconds")
                     gaslimit_queue.put(last_tps)
                     gas += gas_step
             except Exception as e:
-                print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
-                    str(interval), str(gas), e))
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print('Failed execution with configuration %s seconds and %s gas limit. Reason: %s' % (
+                        str(interval), str(gas), e))
                 results[interval][gas] = -1
                 gaslimit_queue.put(-1)
                 # Crash found, yes
                 if tries > trials:
                     stop_reached = True
-                    print("Crash in benchmarking execution, last feasible gas limit found")
+                    if verbose_level >= VERBOSE_LEVEL_1:
+                        print("Crash in benchmarking execution, last feasible gas limit found")
                 else:
+                    if verbose_level >= VERBOSE_LEVEL_1:
+                        print("Tool needs more data, continue with interval " + str(interval) + " seconds")
                     gas += gas_step
 
             tries += 1
@@ -284,17 +342,21 @@ def find_optimal_parameters():
                 max_value = value
                 max_key = key
         last_peak = max_value
-        print(
-            "Peak in block interval " + str(interval) + " seconds found. Found in "
-            + str(max_key) + " gas limit with " + str(last_peak) + " TPS.")
+        if verbose_level >= VERBOSE_LEVEL_1:
+            print(
+                "Peak in block interval " + str(interval) + " seconds found. Found in "
+                + str(max_key) + " gas limit with " + str(last_peak) + " TPS.")
         # saving the last peak in the array of peaks
         peaks.append({str(interval) + ":" + str(max_key): max_value})
         # can we improve more the tps?
         if len(peaks) > trials:
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print("Checking to continue for more intervals or not")
             pos = trials + 1
             improvement = False
             while pos > 1:
-                print("Peak calc: " + str(peaks[-pos].values()))
+                if verbose_level >= VERBOSE_LEVEL_2:
+                    print("Peak calc: " + str(peaks[-pos].values()))
                 tmp = 1 - (next(iter(peaks[-pos].values())) / last_peak)
                 if tmp > sensitivity:
                     improvement = True
@@ -302,12 +364,17 @@ def find_optimal_parameters():
             if not improvement:
                 # no
                 optimal = True
-                print("Improvement less than the sensitivity given, last feasible combination found")
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print("Improvement less than the sensitivity given, peak found")
             else:
-                # yes
+                # no
+                if verbose_level >= VERBOSE_LEVEL_1:
+                    print("No improvement found, continue execution")
                 interval += interval_step
         else:
-            # yes
+            # no
+            if verbose_level >= VERBOSE_LEVEL_1:
+                print("Tool needs more data, continue execution")
             interval += interval_step
 
     # no more improvement expected, getting the maximum tps with its parameters
@@ -323,22 +390,26 @@ def find_optimal_parameters():
 
 
 if __name__ == '__main__':
-    print('Starting tool execution...')
+    print('Starting tool execution')
     start_time = time.time()
     # Backing up old results
-    run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level==VERBOSE_LEVEL_2)
+    run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
 
     # Building SUT for the first time
+    print('Building the SUT')
     run_file(
         ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
          str(config['test_param']['maxInterval']),
-         str(config['test_param']['defaultGas']),
-         str(user_input)], verbose=verbose_level>=VERBOSE_LEVEL_1)
-
+         str(config['test_param']['defaultGas']), str(gcp_setup),
+         '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+        verbose=verbose_level >= VERBOSE_LEVEL_2)
+    print('SUT successfully built')
+    print('Starting calculation of optimal block interval and block gas limit for maximum throughput')
     result = find_optimal_parameters()
     print("Best result found: " + str(result))
-    print('Aggregating all the workload reports')
-    run_file(['python', _get_path(AGGREGATE_RESULTS_PATH)], verbose=verbose_level==VERBOSE_LEVEL_0)
+    if verbose_level >= VERBOSE_LEVEL_1:
+        print('Aggregating all the workload reports')
+    run_file(['python', _get_path(AGGREGATE_RESULTS_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
     exec_time = (time.time() - start_time)
     print("Execution time: " + str(exec_time))
     exit(0)

--- a/bin/main.py
+++ b/bin/main.py
@@ -111,11 +111,11 @@ def find_min_interval():
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('Benchmarking to find minimum block interval value, current configuration ' + str(
                     interval) + ' seconds and ' +
-                    str(config['test_param']['defaultGas']) + ' gas limit.')
+                      str(config['test_param']['defaultGas']) + ' gas limit.')
                 print('Building SUT')
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']), str(interval),
-                 str(config['test_param']['defaultGas']), gcp_setup,
+                 str(config['test_param']['defaultGas']), "0",
                  '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
@@ -161,7 +161,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), "0", '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level == VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -196,7 +196,7 @@ def find_min_gas_limit(interval):
             run_file(
                 ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                  str(interval),
-                 str(upper_bound), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                 str(upper_bound), "0", '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                 verbose=verbose_level >= VERBOSE_LEVEL_2)
             if verbose_level >= VERBOSE_LEVEL_1:
                 print('SUT successfully built')
@@ -272,7 +272,7 @@ def find_optimal_parameters():
                 run_file(
                     ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
                      str(interval),
-                     str(gas), gcp_setup, '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+                     str(gas), "0", '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
                     verbose=verbose_level >= VERBOSE_LEVEL_2)
                 if verbose_level >= VERBOSE_LEVEL_1:
                     print('SUT successfully built')
@@ -400,18 +400,19 @@ if __name__ == '__main__':
     # Backing up old results
     run_file(['python', _get_path(BACKUP_PATH)], verbose=verbose_level == VERBOSE_LEVEL_2)
 
-
     # Building SUT for the first time
     print('Checking if the SUT needs to be built for the first time.')
-    if gcp_setup == GCP_SETUP_1:
+    try:
         run_file(
             ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
-            str(config['test_param']['maxInterval']),
-            str(config['test_param']['defaultGas']), '1',
-            '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
-            verbose=verbose_level >= VERBOSE_LEVEL_2)
-        print('SUT successfully built')
-
+             str(config['test_param']['maxInterval']),
+             str(config['test_param']['defaultGas']), str(gcp_setup),
+             '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
+            verbose=verbose_level == VERBOSE_LEVEL_2)
+    except Exception as e:
+        print("Error executing Optibench tool. Ocurred an error when building the SUT.")
+        exit(-1)
+    print('SUT successfully built')
 
     print('Starting calculation of optimal block interval and block gas limit for maximum throughput')
     result = find_optimal_parameters()

--- a/bin/main.py
+++ b/bin/main.py
@@ -13,15 +13,29 @@ CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 # 2: Print everything
 
 verbose_level = int(sys.argv[1])
+gcp_setup = int(sys.argv[2])
 
 VERBOSE_LEVEL_0 = 0
 VERBOSE_LEVEL_1 = 1
 VERBOSE_LEVEL_2 = 2
+ALLOWED_VERBOSE_LEVELS = (VERBOSE_LEVEL_0, VERBOSE_LEVEL_1, VERBOSE_LEVEL_2)
 
-gcp_setup = int(sys.argv[2])
+if verbose_level not in ALLOWED_VERBOSE_LEVELS:
+    print('You can use only next verbose levels: {}'.format(
+        ', '.join(map(str, ALLOWED_VERBOSE_LEVELS)))
+    )
+    exit(1)
 
 GCP_SETUP_0 = 0
 GCP_SETUP_1 = 1
+ALLOWED_GCP_SETUP_LEVELS = (GCP_SETUP_0, GCP_SETUP_1)
+
+if gcp_setup not in ALLOWED_GCP_SETUP_LEVELS:
+    print('You can use only next GCP setup levels: {}'.format(
+        ', '.join(map(str, ALLOWED_GCP_SETUP_LEVELS)))
+    )
+    exit(1)
+
 
 ANALYZER_PATH = "analyzer/"
 SUT_PATH = "sut/"
@@ -55,14 +69,6 @@ def load_config(path):
 config = load_config(CONFIG_PATH)
 
 
-#def run_file(file_path, verbose=True):
-#    process = subprocess.Popen(
-#        file_path,
-#        stdout=subprocess.PIPE,
-#        stderr=subprocess.PIPE,
-#        universal_newlines=True
-#    )
-
 def run_file(file_path, verbose=True):
     process = subprocess.Popen(
         file_path,
@@ -93,31 +99,6 @@ def run_file(file_path, verbose=True):
                         file_path[1],
                     )
                 )
-
-            break
-
-    while True:
-        output = process.stdout.readline()
-        err_output = process.stderr.readline()
-        if verbose:
-            print(output.strip())
-            print(err_output.strip())
-
-        return_code = process.poll()
-        if return_code is not None:
-            if return_code:
-                raise Exception(
-                    'File "{}" has not finished successfully'.format(
-                        file_path[1],
-                    )
-                )
-
-            for output in process.stdout.readlines():
-                if verbose:
-                    print(output.strip())
-            for output in process.stderr.readlines():
-                if verbose:
-                    print(output.strip())
 
             break
 

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -13,18 +13,22 @@ INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 
-CURRENT_BOOTNODE=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
-
+RUNNING_VMS=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
 if [ ${NEW_SETUP} == "0" ]
 then
-  if [ ${CURRENT_BOOTNODE} == ${NUMBER_NODES} ]
+  if [ ${RUNNING_VMS} == ${NUMBER_NODES} ]
   then
-    echo #${CURRENT_BOOTNODE}
-    else
-      echo "Please check your GCP setup."
+    echo
+  else
+      if [ RUNNING_VMS != 0 ]
+      then
+        ${NUMBER_NODES}=${RUNNING_VMS}
+        echo "Disregarding number of nodes entered in config file."
+      else
+        echo "Existing setup has zero running VMs on Google Cloud."
       exit 1
+      fi
   fi
-else
   echo
 fi
 

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -15,6 +15,21 @@ INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 
+CURRENT_BOOTNODE=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
+
+if [ ${NEW_SETUP} == "0" ]
+then
+  if [ ${CURRENT_BOOTNODE} == ${NUMBER_NODES} ]
+  then
+    echo #${CURRENT_BOOTNODE}
+    else
+      echo "Please check your GCP setup."
+      exit 1
+  fi
+else
+  echo
+fi
+
 #receiving the values of Username, Password and NetworkID from config.json
 USERNAME=$(jq -r '.USERNAME'  ../config/config.json)
 PASSWORD=$(jq -r '.PASSWORD'  ../config/config.json)

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -14,22 +14,12 @@ BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 
 RUNNING_VMS=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
-if [ ${NEW_SETUP} == "0" ]
+if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
 then
-  if [ ${RUNNING_VMS} == ${NUMBER_NODES} ]
-  then
-    exit 0
-  else
-      if [ RUNNING_VMS != 0 ]
-      then
-        ${NUMBER_NODES}=${RUNNING_VMS}
-        echo "Disregarding number of nodes entered in config file."
-      else
-        echo "Existing setup has zero running VMs on Google Cloud."
-      exit 1
-      fi
-  fi
-  echo
+    echo ${RUNNING_VMS}
+    echo ${NUMBER_NODES}
+    echo "Please check your existing Google cloud setup."
+    exit 1
 fi
 
 #receiving the values of Username, Password and NetworkID from config.json

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -4,8 +4,6 @@
 
 set -e
 
-#################################################################################
-
 NUMBER_NODES=${1}
 BLOCK_INTERVAL=${2}
 BLOCK_SIZE=${3}
@@ -35,10 +33,17 @@ USERNAME=$(jq -r '.USERNAME'  ../config/config.json)
 PASSWORD=$(jq -r '.PASSWORD'  ../config/config.json)
 NETWORK_ID=$(jq -r '.NETWORK_ID'  ../config/config.json)
 
-CURRENT_BOOTNODE=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
-#################################################################################
+# clean previous sut
 
-function create_new() {
+if [ X${NEW_SETUP} == "X1" ]
+then
+echo DELETING PREVIOUS SETUP, THIS MIGHT TAKE SOME TIME...
+echo
+echo | gcloud -q compute instance-groups managed delete ${INSTANCE_GROUP_NAME} ${GCLOUD_OUTPUT} || true
+echo | gcloud -q compute instances delete ${BOOT_NODE_NAME} ${GCLOUD_OUTPUT} || true
+echo
+echo PREVIOUS SETUP DELETED
+
 # run bootnode
 echo ---- CREATING BOOTNODE ----
 gcloud compute instances create ${BOOT_NODE_NAME} --source-instance-template ${INSTANCE_TEMPLATE} ${GCLOUD_OUTPUT}
@@ -59,56 +64,15 @@ gcloud compute instance-groups managed set-autoscaling ${INSTANCE_GROUP_NAME} \
   --max-num-replicas=${NUMBER_NODES} \
   --min-num-replicas=${NUMBER_NODES} \
    ${GCLOUD_OUTPUT}
-}
-
-# clean previous sut
-function delete_previous() {
-echo DELETING PREVIOUS SETUP, THIS MIGHT TAKE SOME TIME...
-echo
-echo | gcloud -q compute instance-groups managed delete ${INSTANCE_GROUP_NAME} || true
-echo | gcloud -q compute instances delete ${BOOT_NODE_NAME} || true
-echo
-echo PREVIOUS SETUP DELETED
-}
-
-function check_user_input() {
-while echo "Checking your existing Google Cloud project setup."
-do
-    if [ ${NEW_SETUP} -eq 1 ]
-    then
-            delete_previous
-            sleep 1
-            create_new
-            break
-
-    elif [ $CURRENT_BOOTNODE -eq $NUMBER_NODES ]
-    then
-            echo "Google Cloud setup verified successfully."
-            break
-    else
-        echo -ne '\n'
-        echo "Please check your existing Google Cloud project setup."
-        exit 0
-    fi
-done
-}
-
-if [ $NEW_SETUP -le 1 ]
-    then
-        check_user_input
-else
-    echo -ne '\n'
-    echo "Invalid input. Please enter either 0 or 1."
-    exit 0
-fi
 
 echo SLEEPING FOR 30 SECONDS TO MAKE SURE INSTANCES ARE UP!
 sleep 30
+fi
 
 IP_BOOTNODE=$(gcloud compute instances list --filter="name~${BOOT_NODE_NAME}" --format='value(INTERNAL_IP)')
-gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "killall bootnode || true"
-gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "rm -f boot.key && bootnode -genkey boot.key"
-gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "nohup bootnode -nodekey boot.key -addr 0.0.0.0:30310 > /dev/null 2>&1 &"
+gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "killall bootnode || true" ${GCLOUD_OUTPUT}
+gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "rm -f boot.key && bootnode -genkey boot.key" ${GCLOUD_OUTPUT}
+gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "nohup bootnode -nodekey boot.key -addr 0.0.0.0:30310 > /dev/null 2>&1 &" ${GCLOUD_OUTPUT}
 BOOTNODE_PID=$(gcloud compute ssh ${USERNAME}@${BOOT_NODE_NAME} --command "pgrep bootnode || true")
 if [ X${BOOTNODE_PID} == "X" ]
 then
@@ -132,9 +96,9 @@ ACCOUNT_LIST=()
 echo ---- CREATING ACCOUNTS ON NODES ----
 for index in ${!INSTANCE_LIST[@]}; do
     echo CREATING GETH ACCOUNT ON ${INSTANCE_LIST[index]}
-    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "rm -rf .ethereum"
-    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "killall geth || true"
-    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "echo ${PASSWORD} > password && geth --datadir .ethereum/ account new --password password"
+    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "rm -rf .ethereum" ${GCLOUD_OUTPUT}
+    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "killall geth || true" ${GCLOUD_OUTPUT}
+    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "echo ${PASSWORD} > password && geth --datadir .ethereum/ account new --password password" ${GCLOUD_OUTPUT}
     ACCOUNT=$(gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "geth --nousb --datadir .ethereum/ account list | cut -d "{" -f2 | cut -d "}" -f1")
     ACCOUNT_LIST[index]=${ACCOUNT}
 done
@@ -162,14 +126,14 @@ jq -c ".gasLimit = \"0x${gaslimit}\"" genesis.json > tmp.$$.json && mv tmp.$$.js
 echo ---- CONFIGURING AND RUNNING GETH IN NODES ----
 for index in ${!INSTANCE_LIST[@]}; do
     echo GENESIS INIT ON ${INSTANCE_LIST[index]}
-    gcloud compute scp genesis.json ${USERNAME}@${INSTANCE_LIST[index]}:~/genesis.json
-    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "geth --nousb --datadir .ethereum/ init genesis.json"
+    gcloud compute scp genesis.json ${USERNAME}@${INSTANCE_LIST[index]}:~/genesis.json ${GCLOUD_OUTPUT}
+    gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "geth --nousb --datadir .ethereum/ init genesis.json" ${GCLOUD_OUTPUT}
     echo
     echo GENESIS INITIALISED on ${INSTANCE_LIST[index]}
     ACCOUNT=$(gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "geth --nousb --datadir .ethereum/ account list | cut -d "{" -f2 | cut -d "}" -f1")
     #start the node
     gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "nohup geth --datadir .ethereum/ --syncmode 'full' --port 30311 --rpc --rpcaddr '0.0.0.0' --rpcport 8501 --rpcapi 'personal,db,eth,net,web3,txpool,miner' --bootnodes \"${BOOTNODE_ENODE}\" --networkid ${NETWORK_ID} --gasprice '1' --unlock 0x${ACCOUNT} --password password --allow-insecure-unlock --nousb --mine --rpccorsdomain '*' --nat 'any' > /dev/null 2>&1 &"
-    GETH=$( gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "pgrep geth")
+    GETH=$( gcloud compute ssh ${USERNAME}@${INSTANCE_LIST[index]} --command "pgrep geth" ${GCLOUD_OUTPUT})
     if [ X${GETH} == "X" ]
     then
         echo geth process is not running on nodes

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -16,9 +16,10 @@ INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 RUNNING_VMS=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
 if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
 then
-    echo ${RUNNING_VMS}
-    echo ${NUMBER_NODES}
-    echo "Please check your existing Google cloud setup."
+    printf 'The number of nodes and VMs are not equal, please check your existing Google cloud setup and the config file. '
+    echo "Number of running VMs: ${RUNNING_VMS}"
+    echo "Number of nodes configured: ${NUMBER_NODES}"
+
     exit 1
 fi
 

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -10,6 +10,7 @@ NUMBER_NODES=${1}
 BLOCK_INTERVAL=${2}
 BLOCK_SIZE=${3}
 NEW_SETUP=${4}
+GCLOUD_OUTPUT=${5}
 INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -13,6 +13,12 @@ INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 
+if [ ${NEW_SETUP} != '0' ] && [ ${NEW_SETUP} != '1' ]
+then
+  printf "Invalid argument. Please enter 0 or 1"
+  exit 1
+fi
+
 RUNNING_VMS=$(gcloud compute instances list --filter="running AND name~${BOOT_NODE_NAME}"|wc -l|sed 's/ //g')
 if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
 then
@@ -22,6 +28,7 @@ then
 
     exit 1
 fi
+
 
 #receiving the values of Username, Password and NetworkID from config.json
 USERNAME=$(jq -r '.USERNAME'  ../config/config.json)

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -18,7 +18,7 @@ if [ ${NEW_SETUP} == "0" ]
 then
   if [ ${RUNNING_VMS} == ${NUMBER_NODES} ]
   then
-    echo
+    exit 0
   else
       if [ RUNNING_VMS != 0 ]
       then

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -13,7 +13,7 @@ INSTANCE_GROUP_NAME=ethereum-sut-group
 BOOT_NODE_NAME=bootnode
 INSTANCE_TEMPLATE=$(jq -r '.eth_param.templateName'  ../config/config.json)
 
-RUNNING_VMS=$(gcloud compute instances list --filter="running" | grep -w 'ethereum-sut' | wc -l)
+RUNNING_VMS=$(gcloud compute instances list --filter="running AND name~${BOOT_NODE_NAME}"|wc -l|sed 's/ //g')
 if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
 then
     printf 'The number of nodes and VMs are not equal, please check your existing Google cloud setup and the config file. '


### PR DESCRIPTION
## Description
Added flag in the main script to get the user's input: 1 or 0
(0: use existing setup, 1: clean existing setup and a create a new one)

When the user selects 1: Clean the existing setup and create a new one

When the user selects 0: Check whether the number of nodes mentioned by the user in the config file is equal to the number of running VMs (in google cloud project) or not.

## Related Issue
#91 

## Motivation and Context
It has been added to verify the existing configuration first and then use it.
Also, it is not a good idea to create a new setup without permission.

## How Has This Been Tested?
By executing the following in the bin folder:
python3 main.py 2 0 (when the number of nodes in config file = number of running VMs on GCP)
python3 main.py 2 0 (when the number of nodes in config file != number of running VMs on GCP)
python3 main.py 2 1


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

