### PR TITLE
fixing feature to count the number of running VMs correctly

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -457,7 +457,7 @@ if __name__ == '__main__':
         run_file(
             ['bash', _get_path(DEPLOY_SUT_PATH), str(config['eth_param']['nodeNumber']),
              str(config['test_param']['maxInterval']),
-             str(config['test_param']['defaultGas']), '1',
+             str(config['test_param']['defaultGas']), str(gcp_setup),
              '--no-user-output-enabled' if verbose_level == VERBOSE_LEVEL_0 else ''],
             verbose=verbose_level == VERBOSE_LEVEL_2)
     except Exception as e:

--- a/bin/sut/deploy-sut.sh
+++ b/bin/sut/deploy-sut.sh
@@ -20,15 +20,15 @@ then
   exit 1
 fi
 
-#RUNNING_VMS=$(gcloud compute instances list --filter="running AND name~${BOOT_NODE_NAME}"|wc -l|sed 's/ //g')
-#if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
-#then
-#    printf 'The number of nodes and VMs are not equal, please check your existing Google cloud setup and the config file. '
-#    echo "Number of running VMs: ${RUNNING_VMS}"
-#    echo "Number of nodes configured: ${NUMBER_NODES}"
-#
-#    exit 1
-#fi
+RUNNING_VMS=$(gcloud compute instances list --filter="running AND name~${BOOT_NODE_NAME}"|wc -l|sed 's/ //g')
+if [[ ${NEW_SETUP} == '0' && ${RUNNING_VMS} != ${NUMBER_NODES} ]]
+then
+    printf 'The number of nodes and VMs are not equal, please check your existing Google cloud setup and the config file. '
+    echo "Number of running VMs: ${RUNNING_VMS}"
+    echo "Number of nodes configured: ${NUMBER_NODES}"
+
+    exit 1
+fi
 
 
 #receiving the values of Username, Password and NetworkID from config.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added error handling to handle any possible user input.

## Related Issue
#118 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
By executing the following in the bin folder:

python3 main.py 2 0
python3 main.py 2 1

Test Case - 1 : configure 3 nodes in config file and have 2 VMs running on Google cloud
Test Case - 2 : configure 2 nodes in config file and have 2 VMs running on Google cloud
Test Case - 3 : configure 2 nodes in config file and have no VMs running on Google cloud

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist contributor:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
